### PR TITLE
consistently set up mamba in build_and_test workflow on Windows, Mac and Linux

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Setup mamba (linux, macos)
         if: runner.os != 'Windows'
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3.0.1
         with:
           miniforge-variant: Mambaforge-pypy3
           miniforge-version: latest
@@ -66,7 +66,7 @@ jobs:
 
       - name: Setup mamba (windows)
         if: runner.os == 'Windows'
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3.0.1
         with:
           miniforge-variant: Mambaforge-pypy3
           miniforge-version: latest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,14 +61,14 @@ jobs:
           miniforge-version: latest
           environment-file: mm-workflows/install/system_deps.yml
           activate-environment: mm
-          use-mamba: true
           channels: conda-forge
           python-version: "3.9.*" # pypy is not yet compatible with 3.10 and 3.11
 
-      - name: Setup conda (windows)
+      - name: Setup mamba (windows)
         if: runner.os == 'Windows'
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
+          miniforge-variant: Mambaforge-pypy3
           miniforge-version: latest
           environment-file: mm-workflows/install/system_deps_windows.yml
           activate-environment: mm


### PR DESCRIPTION
Exact same Mamba setup for all three platforms